### PR TITLE
Utc time stamp

### DIFF
--- a/NSDate+Helper.h
+++ b/NSDate+Helper.h
@@ -41,7 +41,7 @@
 - (NSUInteger)hour;
 - (NSUInteger)minute;
 - (NSUInteger)year;
-- (NSTimeInterval)utcTimeStamp; //full seconds since
+- (long int)utcTimeStamp; //full seconds since
 
 + (NSDate *)dateFromString:(NSString *)string;
 + (NSDate *)dateFromString:(NSString *)string withFormat:(NSString *)format;

--- a/NSDate+Helper.m
+++ b/NSDate+Helper.m
@@ -93,15 +93,8 @@
 	return [weekdayComponents year];
 }
 
-- (NSTimeInterval)utcTimeStamp{
-    NSDateComponents *comps = [[NSCalendar currentCalendar]
-                               components:NSDayCalendarUnit | NSYearCalendarUnit | NSMonthCalendarUnit
-                               fromDate:[NSDate date]];
-    [comps setHour:0];
-    [comps setMinute:0];
-    [comps setSecond:[[NSTimeZone systemTimeZone] secondsFromGMT]];
-    
-    return [[[NSCalendar currentCalendar] dateFromComponents:comps] timeIntervalSince1970];
+- (long int)utcTimeStamp{
+    return lround(floor([self timeIntervalSince1970]));
 }
 
 - (NSUInteger)weekday {


### PR DESCRIPTION
I added a method that returns the timestamp as a long int, basically flooring the NSTimeInterval. This method is required when talking to backends, where Unix Timestamps are usually Integers or Longs
