### PR TITLE
iOS8 warnings

### DIFF
--- a/NSDate+Helper.m
+++ b/NSDate+Helper.m
@@ -81,7 +81,7 @@ static NSDateFormatter *_displayFormatter = nil;
  */
 - (NSUInteger)daysAgo {
     NSCalendar *calendar = [[self class] sharedCalendar];
-    NSDateComponents *components = [calendar components:(NSDayCalendarUnit)
+    NSDateComponents *components = [calendar components:(NSCalendarUnitDay)
                                                fromDate:self
                                                  toDate:[NSDate date]
                                                 options:0];
@@ -111,26 +111,26 @@ static NSDateFormatter *_displayFormatter = nil;
 			text = NSLocalizedString(@"Yesterday", nil);
 			break;
 		default:
-			text = [NSString stringWithFormat:@"%ld days ago", (NSInteger)daysAgo];
+			text = [NSString stringWithFormat:@"%ld days ago", (long)daysAgo];
 	}
 	return text;
 }
 
 - (NSUInteger)hour {
     NSCalendar *calendar = [[self class] sharedCalendar];
-    NSDateComponents *weekdayComponents = [calendar components:(NSHourCalendarUnit) fromDate:self];
+    NSDateComponents *weekdayComponents = [calendar components:(NSCalendarUnitHour) fromDate:self];
 	return [weekdayComponents hour];
 }
 
 - (NSUInteger)minute {
     NSCalendar *calendar = [[self class] sharedCalendar];
-    NSDateComponents *weekdayComponents = [calendar components:(NSMinuteCalendarUnit) fromDate:self];
+    NSDateComponents *weekdayComponents = [calendar components:(NSCalendarUnitMinute) fromDate:self];
 	return [weekdayComponents minute];
 }
 
 - (NSUInteger)year {
     NSCalendar *calendar = [[self class] sharedCalendar];
-    NSDateComponents *weekdayComponents = [calendar components:(NSYearCalendarUnit) fromDate:self];
+    NSDateComponents *weekdayComponents = [calendar components:(NSCalendarUnitYear) fromDate:self];
 	return [weekdayComponents year];
 }
 
@@ -139,14 +139,14 @@ static NSDateFormatter *_displayFormatter = nil;
 }
 
 - (NSUInteger)weekday {
-    NSDateComponents *weekdayComponents = [[[self class] sharedCalendar] components:(NSWeekdayCalendarUnit) fromDate:self];
+    NSDateComponents *weekdayComponents = [[[self class] sharedCalendar] components:(NSCalendarUnitWeekday) fromDate:self];
 	return [weekdayComponents weekday];
 }
 
 - (NSUInteger)weekNumber {
     NSCalendar *calendar = [[self class] sharedCalendar];
-    NSDateComponents *dateComponents = [calendar components:(NSWeekCalendarUnit) fromDate:self];
-    return [dateComponents week];
+    NSDateComponents *dateComponents = [calendar components:(NSCalendarUnitWeekOfYear) fromDate:self];
+    return [dateComponents weekday];
 }
 
 + (NSDate *)dateFromString:(NSString *)string {
@@ -176,7 +176,7 @@ static NSDateFormatter *_displayFormatter = nil;
 	 * else display as Nov 11, 2008
 	 */
 	NSDate *today = [NSDate date];
-    NSDateComponents *offsetComponents = [[self sharedCalendar] components:(NSYearCalendarUnit | NSMonthCalendarUnit | NSDayCalendarUnit)
+    NSDateComponents *offsetComponents = [[self sharedCalendar] components:(NSCalendarUnitYear | NSCalendarUnitMonth | NSCalendarUnitDay)
                                                                   fromDate:today];
 	NSDate *midnight = [[self sharedCalendar] dateFromComponents:offsetComponents];
 	NSString *displayString = nil;
@@ -206,7 +206,7 @@ static NSDateFormatter *_displayFormatter = nil;
 		} else {
 			// check if same calendar year
 			NSInteger thisYear = [offsetComponents year];
-			NSDateComponents *dateComponents = [[self sharedCalendar] components:(NSYearCalendarUnit | NSMonthCalendarUnit | NSDayCalendarUnit)
+			NSDateComponents *dateComponents = [[self sharedCalendar] components:(NSCalendarUnitYear | NSCalendarUnitMonth | NSCalendarUnitDay)
                                                             fromDate:date];
 			NSInteger thatYear = [dateComponents year];
 			if (thatYear >= thisYear) {
@@ -245,7 +245,6 @@ static NSDateFormatter *_displayFormatter = nil;
 }
 
 - (NSString *)stringWithFormat:(NSString *)format {
-	[[self class] initializeStatics];
 	[[[self class] sharedDateFormatter] setDateFormat:format];
 	NSString *timestamp_str = [[[self class] sharedDateFormatter] stringFromDate:self];
 	return timestamp_str;
@@ -267,14 +266,14 @@ static NSDateFormatter *_displayFormatter = nil;
 	// we'll use the default calendar and hope for the best
 	NSCalendar *calendar = [[self class] sharedCalendar];
     NSDate *beginningOfWeek = nil;
-	BOOL ok = [calendar rangeOfUnit:NSWeekCalendarUnit startDate:&beginningOfWeek
+	BOOL ok = [calendar rangeOfUnit:NSCalendarUnitWeekOfYear startDate:&beginningOfWeek
 						   interval:NULL forDate:self];
 	if (ok) {
 		return beginningOfWeek;
 	}
 	// couldn't calc via range, so try to grab Sunday, assuming gregorian style
 	// Get the weekday component of the current date
-	NSDateComponents *weekdayComponents = [calendar components:NSWeekdayCalendarUnit fromDate:self];
+	NSDateComponents *weekdayComponents = [calendar components:NSCalendarUnitWeekday fromDate:self];
 	/*
 	 Create a date components to represent the number of days to subtract from the current date.
 	 The weekday value for Sunday in the Gregorian calendar is 1, so subtract 1 from the number of days to subtract from the date in question.  (If today's Sunday, subtract 0 days.)
@@ -287,7 +286,7 @@ static NSDateFormatter *_displayFormatter = nil;
 	[componentsToSubtract release];
 #endif
 	//normalize to midnight, extract the year, month, and day components and create a new date from those components.
-	NSDateComponents *components = [calendar components:(NSYearCalendarUnit | NSMonthCalendarUnit | NSDayCalendarUnit)
+	NSDateComponents *components = [calendar components:(NSCalendarUnitYear | NSCalendarUnitMonth | NSCalendarUnitDay)
 											   fromDate:beginningOfWeek];
 	return [calendar dateFromComponents:components];
 }
@@ -295,7 +294,7 @@ static NSDateFormatter *_displayFormatter = nil;
 - (NSDate *)beginningOfDay {
     NSCalendar *calendar = [[self class] sharedCalendar];
     // Get the weekday component of the current date
-	NSDateComponents *components = [calendar components:(NSYearCalendarUnit | NSMonthCalendarUnit | NSDayCalendarUnit)
+	NSDateComponents *components = [calendar components:(NSCalendarUnitYear | NSCalendarUnitMonth | NSCalendarUnitDay)
 											   fromDate:self];
 	return [calendar dateFromComponents:components];
 }
@@ -303,7 +302,7 @@ static NSDateFormatter *_displayFormatter = nil;
 - (NSDate *)endOfWeek {
     NSCalendar *calendar = [[self class] sharedCalendar];
     // Get the weekday component of the current date
-	NSDateComponents *weekdayComponents = [calendar components:NSWeekdayCalendarUnit fromDate:self];
+	NSDateComponents *weekdayComponents = [calendar components:NSCalendarUnitWeekday fromDate:self];
 	NSDateComponents *componentsToAdd = [[NSDateComponents alloc] init];
 	// to get the end of week for a particular date, add (7 - weekday) days
 	[componentsToAdd setDay:(7 - [weekdayComponents weekday])];

--- a/NSDate+Helper.m
+++ b/NSDate+Helper.m
@@ -146,7 +146,7 @@ static NSDateFormatter *_displayFormatter = nil;
 - (NSUInteger)weekNumber {
     NSCalendar *calendar = [[self class] sharedCalendar];
     NSDateComponents *dateComponents = [calendar components:(NSCalendarUnitWeekOfYear) fromDate:self];
-    return [dateComponents weekday];
+    return [dateComponents weekOfYear];
 }
 
 + (NSDate *)dateFromString:(NSString *)string {


### PR DESCRIPTION
Renamed CFXXXCalendarUnit deprecated constraints to new CFCalendarUnitXXX.